### PR TITLE
Implement extra options given in the config

### DIFF
--- a/activeset.go
+++ b/activeset.go
@@ -27,8 +27,9 @@ import (
 
 // InterfaceInfo contains basic information about a specific interface entry.
 type InterfaceInfo struct {
-	Threads   int
-	ClusterID int
+	Threads      int
+	ClusterID    int
+	ExtraOptions map[string]string
 }
 
 // ActiveSet contains descriptions of the currently connected interfaces.
@@ -92,8 +93,9 @@ func (a *ActiveSet) ToYAML(tmpl *template.Template, config *Config) (string, err
 	}
 	for intf := range a.Ifaces {
 		a.Ifaces[intf] = InterfaceInfo{
-			Threads:   int(math.Ceil(float64(threads) * (float64(config.Ifaces[intf].ThreadWeight) / float64(totalweight)))),
-			ClusterID: config.Ifaces[intf].ClusterID,
+			Threads:      int(math.Ceil(float64(threads) * (float64(config.Ifaces[intf].ThreadWeight) / float64(totalweight)))),
+			ClusterID:    config.Ifaces[intf].ClusterID,
+			ExtraOptions: config.Ifaces[intf].ExtraOptions,
 		}
 	}
 	buf := new(bytes.Buffer)

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ import (
 type ConfIface struct {
 	ThreadWeight int
 	ClusterID    int
+	ExtraOptions map[string]string `yaml:"extraopts,omitempty"`
 }
 
 // Config represents basic configuration parsed from a file, such as interfaces

--- a/interfaces.tmpl
+++ b/interfaces.tmpl
@@ -3,18 +3,9 @@
 af-packet:{{ range $iface, $vals := . }}
   - interface: {{ $iface }}
     threads: {{ $vals.Threads }}
-    cluster-id: {{ $vals.ClusterID }}
-    cluster-type: cluster_flow
-    defrag: yes
-    rollover: yes
-    use-mmap: yes
-    tpacket-v3: yes
-    use-emergency-flush: yes
-    buffer-size: 128000
+    cluster-id: {{ $vals.ClusterID }}{{ range $extrakey, $extraval := $vals.ExtraOptions }}
+    {{ $extrakey }}: {{ $extraval}}{{ end }}
 {{ else }}
   - interface: default
     threads: auto
-    use-mmap: yes
-    rollover: yes
-    tpacket-v3: yes
 {{ end }}

--- a/interfaces.tmpl
+++ b/interfaces.tmpl
@@ -3,9 +3,19 @@
 af-packet:{{ range $iface, $vals := . }}
   - interface: {{ $iface }}
     threads: {{ $vals.Threads }}
+    cluster_type: cluster_flow
+    defrag: yes
+    rollover: yes
+    use-mmap: yes
+    tpacket-v3: yes
+    use-emergency-flush: yes
+    buffer-size: 128000
     cluster-id: {{ $vals.ClusterID }}{{ range $extrakey, $extraval := $vals.ExtraOptions }}
     {{ $extrakey }}: {{ $extraval}}{{ end }}
 {{ else }}
   - interface: default
     threads: auto
+    use-mmap: yes
+    rollover: yes
+    tpacket-v3: yes
 {{ end }}


### PR DESCRIPTION
This PR adds support for an optional `extraopts` section in the input interface configuration. All sub-items will then be added to the Suricata `interface` entry in the generated configuration by passing it to the `ExtraOptions` template value entry. So the following:

```yaml
  eth0:
    threadweight: 2
    clusterid: 99
    extraopts:
      cluster-type: cluster_qm
      foo: bar
```
with the template:
```
af-packet:{{ range $iface, $vals := . }}
  - interface: {{ $iface }}
    threads: {{ $vals.Threads }}
    cluster-id: {{ $vals.ClusterID }}{{ range $extrakey, $extraval := $vals.ExtraOptions }}
    {{ $extrakey }}: {{ $extraval}}{{ end }}
{{ else }}
  - interface: default
    threads: auto
    use-mmap: yes
    rollover: yes
    tpacket-v3: yes
{{ end }}
```
would generate (if `eth0` is active):
```yaml
af-packet:
  - interface: eth0
    threads: 8
    cluster-id: 99
    cluster-type: cluster_qm
    foo: bar
```
Closes #2.