### PR TITLE
With systemd, only restart Suricata if it is currently running.

### DIFF
--- a/restart.go
+++ b/restart.go
@@ -69,7 +69,7 @@ func (rm *RestartManager) RestartSuricata() error {
 		return err
 	}
 	finishChan := make(chan string)
-	_, err = conn.RestartUnit(rm.ServiceName, "replace", finishChan)
+	_, err = conn.TryRestartUnit(rm.ServiceName, "replace", finishChan)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using TryRestartUnit instead of RestartUnit simply calls a different DBus API which is documented at <https://www.freedesktop.org/wiki/Software/systemd/dbus/>.This may be bit different from what is described in #6, but querying the unit's state would require using a DBus API (`GetUnitFileState)`) that is not exposed through `github.com/coreos/go-systemd/dbus`.